### PR TITLE
Proposed changes to sfdisk command

### DIFF
--- a/build-pine64-image.sh
+++ b/build-pine64-image.sh
@@ -63,7 +63,8 @@ unxz -k --stdout "$SIMPLEIMAGE" > "$TEMP/$IMAGE"
 # Enlarge
 dd if=/dev/zero bs=1M count=$SIZE >> "$TEMP/$IMAGE"
 # Resize
-echo ", +" | sfdisk -N 2 "$TEMP/$IMAGE"
+#echo ", +" | sfdisk -N 2 "$TEMP/$IMAGE"
+echo ",+,L" | sfdisk "$TEMP/$IMAGE" -L -uS -N2 --force
 
 # Device
 mkdir "$TEMP/boot"


### PR DESCRIPTION
@longsleep: Changes highlighted in the diff where required in the following
build environment running fully updated Debian Jessie/8
 ```shell
    $ uname -r
    3.16.0-4-amd64
    $ cat /etc/debian_version
    8.7
    $ /sbin/sfdisk --version
    sfdisk from util-linux 2.25.2
```
Without the shown modifications sfdisk does not update the disk image size in
the partition table, leading to kpartx complaining that the rootfs partition is
outside the disk boundaries and fails to create /dev/mapper/loopXpX partitions.
This leads to build failure due to not enough size available for rootfs in
debootstrap.